### PR TITLE
buff: doubled the range of whirling blade

### DIFF
--- a/BetaTest266/Scripts/Server/classes/task/MayorSpecialMove.usl
+++ b/BetaTest266/Scripts/Server/classes/task/MayorSpecialMove.usl
@@ -1,7 +1,7 @@
 class CMayorSpecialMove inherit CSpecialActionTask
 	//Kr1s1m: Promoted these real number variables to be fields of the class, instead of local for USLOnTick function.
 	//Badgun Tuning: Mayor Special Move
-	const real m_fRange			= 6.0; // must NOT be 0.0; 
+	const real m_fRange			= 12.0; // must NOT be 0.0; Kr1s1m: Original value was 6.0f. Buffed to 12.0f.
 	const real m_fDmgPercentage	= 25.0;
 	const real m_fMinDmg			= 300.0;
 	const real m_fMaxDmg			= 2000.0;


### PR DESCRIPTION
range increased from 6 to 12, because 6.0 felt super close range (almost touching distance) for a whirlwind