### PR TITLE
added less damage and less defense visual debuffs

### DIFF
--- a/BetaTest266/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/BetaTest266/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -12230,6 +12230,8 @@ class CFightingObj inherit CGameObj
 		m_bWeaponRemoved = p_bEnable; //Kr1s1m: Change the state of weapon removed field to p_bEnable param information
 		if(!p_bEnable)then //Kr1s1m: If we want to reverse the disarm effect...
 			ForceGeneralUpdate(); //Kr1s1m: ...we restore all weapon data from TT and reload the caches and the weapon manager
+			RemoveRangedBuff("less_damage");
+			RemoveRangedBuff("less_defense");
 	        //UpdateFightFactors();
 		else //Kr1s1m: In case that we want to apply the disarm effect:
 			//Kr1s1m: First we stop the attack animations
@@ -12239,6 +12241,8 @@ class CFightingObj inherit CGameObj
 			ClearWeaponCache();
 			//Kr1s1m: Third, we update the visuals and the text
 			UpdateWeapons(GetRightHandWeapon());
+			AddRangedBuff("less_damage");
+			AddRangedBuff("less_defense");
 		endif;
 		//Kr1s1m: Last, we raise up the necessary flags
 		m_bWeaponHasChanged = true;


### PR DESCRIPTION
- units and buildings affected by disarm effect (weapon remove enabled) will have a red sword and red shield circular debuff icons and red swords game field debuff aura
- TODO: In the future if defense is not considered a weapon like in code (depends on the point of view, for a warrior losing his shield logically means to also lose defense value), defense values can be restored from TTree in all cases, so that weapon remove can only make the target harmless but not defenseless