### PR TITLE
added hc taverne gfx flag check

### DIFF
--- a/BetaTest266/Scripts/Server/classes/buildings/Building.usl
+++ b/BetaTest266/Scripts/Server/classes/buildings/Building.usl
@@ -4879,7 +4879,14 @@ class CNPCSeller inherit CBuilding
 				pxAttr^.SetValue("NPCSeller",true);
 			endif;
 		endif;
+		CheckHcTaverne();
 		SetRallySite(true);
+	endproc;
+
+	export proc void CheckHcTaverne()
+		if(GetClassName() == "aje_cook_house" && m_xTechTree.GetValueS(GetObjPath()+"/gfx", "") == "hc_taverne")then
+			SetVisInFOW(true);
+		endif;
 	endproc;
 
 	export proc void CheckTeslaMachine(CObjHndl p_xRally)


### PR DESCRIPTION
- makes tavern visible in Fog of War if its Aje tavern which has hc_taverne graphical flag in TT
- was needed for campaign Mission 5: Holy City