### PR TITLE
added condition which acts as special object for PLDE

### DIFF
--- a/BetaTest266/Scripts/Server/misc/ConditionFactory.usl
+++ b/BetaTest266/Scripts/Server/misc/ConditionFactory.usl
@@ -2106,6 +2106,11 @@ class CConditionPlayerDead inherit CTrigger.ICondition
 
 			if(ms_asValidTypes.FindEntry(pxFightingObj^.GetType().AsString())==-1)then return true; endif;
 			
+			//Kr1s1m: CFightingObj with not selectable, not hitable or invulnerable (from trigger) flags...
+			//Kr1s1m: ...are exceptions (special object) when it comes to Player Dead (PLDE).
+			//Kr1s1m: Used for burning invulnerable buildings in campaign. Works with any combinations of the flags.
+			if(!pxFightingObj^.IsSelectable() || !pxFightingObj^.IsHitable() || pxFightingObj^.GetLDInvulnerable())then return true; endif;
+			
 			if(m_iMode==CConditionPlayerDead.BUILDING_MODE && !m_bCheckPyramid)then
 				var CObjList xList;
 				CBLDGMgr.Get().GetAllBuildings(m_iPlayer,xList);


### PR DESCRIPTION
- any combination of not selectable, not hitable and invulnerable (from trigger), as long as at least one is present, will make the specific object an exception when it is checked for Player Dead (PLDE) condition from SDK