### PR TITLE
TT Stealing effect is now always on

### DIFF
--- a/BetaTest266/Scripts/Game/UI/CommandBarEx/CommandBar.usl
+++ b/BetaTest266/Scripts/Game/UI/CommandBarEx/CommandBar.usl
@@ -4720,17 +4720,19 @@ class CTTHelper
 		var CTechTreeDef xTTDef;
 		xTT=CTechTreeMgr.Get().GetTechTree(xTTDef);
 		var array string asTribes;
-		if(!bTechtreeSteal)then
-			asTribes.AddEntry(sTribe);
-			asTribes.AddEntry("Special");
-		else
-			asTribes.AddEntry("Aje");
-			asTribes.AddEntry("Hu");
-			asTribes.AddEntry("Ninigi");
-			asTribes.AddEntry("SEAS");
-			asTribes.AddEntry("Special");
-			asTribes.AddEntry("World");
-		endif;
+		//if(!bTechtreeSteal)then
+			//asTribes.AddEntry(sTribe);
+			//asTribes.AddEntry("Special");
+		//else
+		//Kr1s1m: TechtreeSteal is now always on. Foreign tribe active and passive specials always work.
+		//Kr1s1m: Server setting still prevents placing foreign tribe buildings when TechtreeSteal is disabled.
+		asTribes.AddEntry("Aje");
+		asTribes.AddEntry("Hu");
+		asTribes.AddEntry("Ninigi");
+		asTribes.AddEntry("SEAS");
+		asTribes.AddEntry("Special");
+		asTribes.AddEntry("World");
+		//endif;
 		var int iCurTribe, iNumTribes=asTribes.NumEntries();
 		for(iCurTribe=0) cond(iCurTribe<iNumTribes) iter(++iCurTribe) do
 			var ^CTechTree.CNode pxActions=xTT.FindNode("/Actions/"+asTribes[iCurTribe]);

--- a/BetaTest266/Scripts/Game/mgr/MirageClnMgr.usl
+++ b/BetaTest266/Scripts/Game/mgr/MirageClnMgr.usl
@@ -988,12 +988,14 @@ class CMirageClnMgr
 	endproc;
 	
 	proc string GetSpecialFocus(string p_sFocus)
-		if(!CheckTechtreeSteal())then
-			if(!p_sFocus.IsEmpty())then
-				m_bFocusBldg=m_asBuildings.FindEntry(p_sFocus)!=-1;
-			endif;
-			return m_sPlayerTribe;
-		endif;
+		//Kr1s1m: TechtreeSteal is now always on. Foreign tribe active and passive specials always work.
+		//Kr1s1m: Server setting still prevents placing foreign tribe buildings when TechtreeSteal is disabled.
+		//if(!CheckTechtreeSteal())then
+			//if(!p_sFocus.IsEmpty())then
+				//m_bFocusBldg=m_asBuildings.FindEntry(p_sFocus)!=-1;
+			//endif;
+			//return m_sPlayerTribe;
+		//endif;
 		var string sSpecial;
 		if(p_sFocus.IsEmpty())then return sSpecial; endif;
 		if(p_sFocus.Left(4)=="aje_")then

--- a/BetaTest266/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/BetaTest266/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -16727,30 +16727,35 @@ class CFightingObj inherit CGameObj
 	endproc;
 	
 	export proc string GetTribeNameForReqMgr()
-		if(m_bTechtreeSteal)then
-			return GetTribeName();
-		else
-			return m_sPTName;
-		endif;
+		//Kr1s1m: TechtreeSteal is now always on. Foreign tribe active and passive specials always work.
+		//Kr1s1m: Server setting still prevents placing foreign tribe buildings when TechtreeSteal is disabled.
+		//if(m_bTechtreeSteal)then
+		return GetTribeName();
+		//else
+			//return m_sPTName;
+		//endif;
 	endproc;
 	
 	export proc bool CheckTribes(^CTechTree.CNode p_pxAction)
-		if(CMirageSrvMgr.Get().TechtreeSteal())then return true; endif;
-		if(p_pxAction==null)then return true; endif;
-		var ^CTechTree.CNode pxCondNode=p_pxAction^.GetSub("conditions");
-		if(pxCondNode==null)then return true; endif;
-		var ^CTechTree.CNode pxTribes=pxCondNode^.GetSub("tribe");
-		if(pxTribes==null)then return true; endif;
-		var bool bCheckTribe = false;
-		var int i, iC = pxTribes^.NumSubs();
-		for(i=0)cond(i<iC)iter(i++)do
-			var ^CTechTree.CNode pxNode = pxTribes^.GetSub(i);
-			if(m_sPTName == pxNode^.GetValue())then
-				bCheckTribe=true;
-				break;
-			endif;
-		endfor;
-		return bCheckTribe;
+		return true;
+		//Kr1s1m: TechtreeSteal is now always on. Foreign tribe active and passive specials always work.
+		//Kr1s1m: Server setting still prevents placing foreign tribe buildings when TechtreeSteal is disabled.
+		//if(CMirageSrvMgr.Get().TechtreeSteal())then return true; endif;
+		//if(p_pxAction==null)then return true; endif;
+		//var ^CTechTree.CNode pxCondNode=p_pxAction^.GetSub("conditions");
+		//if(pxCondNode==null)then return true; endif;
+		//var ^CTechTree.CNode pxTribes=pxCondNode^.GetSub("tribe");
+		//if(pxTribes==null)then return true; endif;
+		//var bool bCheckTribe = false;
+		//var int i, iC = pxTribes^.NumSubs();
+		//for(i=0)cond(i<iC)iter(i++)do
+			//var ^CTechTree.CNode pxNode = pxTribes^.GetSub(i);
+			//if(m_sPTName == pxNode^.GetValue())then
+				//bCheckTribe=true;
+				//break;
+			//endif;
+		//endfor;
+		//return bCheckTribe;
 	endproc;
 	
 	export proc bool GetNoReceiveDamage()


### PR DESCRIPTION
- Foreign tribe active and passive specials always work and are present in command bar. Works for units made with SEAS jail 01 (special barracks/Char prison) or stolen with Tarna. Tarna ability to steal still depends on Old Spirit System Mirage Server setting. Myagi continues being unable to enslave worker while TT-Stealing is off in Mirage Server settings.
- Foreign tribe building menu is available in command bar but ability to place foreign building still depends on TT-Stealing Mirage server setting. If disabled buildings cannot be placed, albeit being visible in command bar. TODO: Visual improvement: Make building menu (B) empty in command bar in such cases where foreign unit is controlled and TT-Stealing is off.