### PR TITLE
dustriders resource tool upgrade now works properly

### DIFF
--- a/BetaTest266/Scripts/Server/classes/task/BuildUpBuilding.usl
+++ b/BetaTest266/Scripts/Server/classes/task/BuildUpBuilding.usl
@@ -349,8 +349,8 @@ class CBuildUpBuilding inherit CTask
 				var ^CGameObj pxObj = xList[i].GetObj();
 				if(pxObj!=null)then
 					var bool bGoAway=false;
-					var ^CCharacter pxChar=cast<CCharacter>(pxObj);
-					if(pxChar==null||pxChar^.IsIdle()) then bGoAway=true; endif;
+					var ^CCharacter pxWorker=cast<CCharacter>(pxObj);
+					if(pxWorker==null||pxWorker^.IsIdle()) then bGoAway=true; endif;
 					if(bGoAway) then
 						var vec3 vDir = pxObj^.GetPos()-pxBldg^.GetPos();
 						vDir.Normalize();
@@ -418,10 +418,22 @@ class CBuildUpBuilding inherit CTask
 		endfor;*/
 		var real fMinTimeFactor=99.9;
 		iterloop(m_axWorkers,i) do
-			var ^CCharacter pxChar = cast<CCharacter>(m_axWorkers[i].GetObj());
-			if(pxChar!=null)then
-				if(fMinTimeFactor>pxChar^.GetSelfTimeFactor())then
-					fMinTimeFactor=pxChar^.GetSelfTimeFactor();
+			var ^CCharacter pxWorker = cast<CCharacter>(m_axWorkers[i].GetObj());
+			if(pxWorker!=null)then
+				var real fWorkerTimeFactor = pxWorker^.GetSelfTimeFactor();
+				//Kr1s1m: Initiate a check for Dustriders Resource Tool Upgrade in order to skip affecting build up speed.
+				//Kr1s1m: This was needed so the upgrade could be restored to its base game state.
+				begin CheckAjeResourceToolUpgrade;
+					var bool bLarryBrother = pxWorker^.GetClassName()=="Larry_s0" || pxWorker^.GetClassName()=="Barry_s0" || pxWorker^.GetClassName()=="Harry_s0";
+					if(pxWorker^.GetClassName()=="aje_worker" || bLarryBrother)then
+						var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "aje_resource_tool_upgrade_1", pxBuilding^.GetTribeName());
+						if(bAjeResourceToolUpgradeInvented)then //Kr1s1m: If Larries or workers have the aje resource tool upgrade...
+							fWorkerTimeFactor = 1.0;//Kr1s1m: ... then treat the current time factor as 100% (base) for the calculations bellow.
+						endif;
+					endif;
+				end CheckAjeResourceToolUpgrade;
+				if(fMinTimeFactor>fWorkerTimeFactor)then
+					fMinTimeFactor=fWorkerTimeFactor;
 				endif;
 			endif;
 		enditerloop;
@@ -469,12 +481,12 @@ class CBuildUpBuilding inherit CTask
 		end CheckSEASBonus;
 		iterloop(m_axWorkers,i) do
 			if(m_axWorkers[i].IsValid())then
-				var ^CCharacter pxChar = cast<CCharacter>(m_axWorkers[i].GetObj());
-				if(pxChar!=null)then
+				var ^CCharacter pxWorker = cast<CCharacter>(m_axWorkers[i].GetObj());
+				if(pxWorker!=null)then
 					if(bTeslaBonus)then
-						pxChar^.AddRangedBuff("faster_buildup");
+						pxWorker^.AddRangedBuff("faster_buildup");
 					else
-						pxChar^.RemoveRangedBuff("faster_buildup");
+						pxWorker^.RemoveRangedBuff("faster_buildup");
 					endif;
 					if(xTempDuration.GetSecondsF()!=0.0)then
 						if(AddProgress(100.0*(xDiff.GetSecondsF()/(xTempDuration.GetSecondsF()))))then

--- a/BetaTest266/Scripts/Server/classes/task/Repair.usl
+++ b/BetaTest266/Scripts/Server/classes/task/Repair.usl
@@ -167,6 +167,17 @@ class CRepair inherit CTargetTask
 			if(pxWorker!=null)then
 				m_fStep+=(fLevelFactor*pxWorker^.GetLevel().ToReal());
 			endif;
+			//Kr1s1m: Initiate a check for Dustriders Resource Tool Upgrade in order to skip affecting repair speed.
+			//Kr1s1m: This was needed so the upgrade could be restored to its base game state.
+			begin CheckAjeResourceToolUpgrade;
+				var bool bLarryBrother = pxWorker^.GetClassName()=="Larry_s0" || pxWorker^.GetClassName()=="Barry_s0" || pxWorker^.GetClassName()=="Harry_s0";
+				if(pxWorker^.GetClassName()=="aje_worker" || bLarryBrother)then
+					var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "aje_resource_tool_upgrade_1", pxBuilding^.GetTribeName());
+					if(bAjeResourceToolUpgradeInvented)then //Kr1s1m: If Larry or worker has the aje resource tool upgrade...
+						fDuration /= m_fTimeFactor; //Kr1s1m: ...undo the effect of the previously multiplied time factor.
+					endif;
+				endif;
+			end CheckAjeResourceToolUpgrade;
 			begin CheckSEASBonus;
 				var bool bSeasBetterToolsInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "seas_better_tools", pxBuilding^.GetTribeName());
 				if(pxWorker^.GetClassName()=="seas_worker")then


### PR DESCRIPTION
- time factor restored like in Base game
- upgrade no longer incorrectly affects build up and repair time like in Base game
- invention obj icons which were gone added back in unit info of workers TODO: Add icon to Larry since he is also affected.