### PR TITLE
SEAS: improved repair, better tools, poison rounds, Ada

### DIFF
--- a/BetaTest266/Scripts/Server/classes/task/BuildUpBuilding.usl
+++ b/BetaTest266/Scripts/Server/classes/task/BuildUpBuilding.usl
@@ -472,7 +472,7 @@ class CBuildUpBuilding inherit CTask
 			if(m_xBuilding.IsValid())then
 				var ^CGameObj pxBldg = m_xBuilding.GetObj();
 				if(pxBldg!=null && cast<CWarpGate>(pxBldg)==null)then
-					var bool bSeasBetterToolsOneInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "improved_repair", pxBuilding^.GetTribeName());
+					var bool bSeasBetterToolsOneInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "seas_better_tools", pxBuilding^.GetTribeName());
 					if(bSeasBetterToolsOneInvented)then
 						xDiff/=SEAS_BETTER_TOOLS;
 					endif;

--- a/BetaTest266/Scripts/Server/classes/task/Repair.usl
+++ b/BetaTest266/Scripts/Server/classes/task/Repair.usl
@@ -179,8 +179,8 @@ class CRepair inherit CTargetTask
 				endif;
 			end CheckAjeResourceToolUpgrade;
 			begin CheckSEASBonus;
-				var bool bSeasBetterToolsInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "seas_better_tools", pxBuilding^.GetTribeName());
-				if(pxWorker^.GetClassName()=="seas_worker")then
+				var bool bSeasBetterToolsInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "improved_repair", pxBuilding^.GetTribeName());
+				if(pxWorker^.GetClassName()=="seas_worker" || pxWorker^.GetClassName()=="tesla_s0")then
 					if(bSeasBetterToolsInvented)then
 						m_fStep*=SEAS_IMPROVED_REPAIR;
 					endif;


### PR DESCRIPTION
- swapped SEAS improved repair and better tools upgrades in order to better match usl script variable names, effect, cost, icons and tooltip description
- improved repair and better tools both work properly with workers and Taslow
- poison rounds (tier 4 Kleeman bonus  for SEAS) now has icon for affected heroes, Ada added to affected heroes, damage and ticks are now based on level for both Ada and Special Suit version of Babbit (SEAS player upgrade)
- Ada's musket range now scales with her level going from 35 to 42 (at tier 5)
- SEAS Reactor core upgrade hidden for the currently disabled seas_jail_part_02