### PR TITLE
fixed Taslow and Babbage chief (tier 5) bonuses

### DIFF
--- a/BetaTest266/Scripts/Server/classes/task/BuildUpBuilding.usl
+++ b/BetaTest266/Scripts/Server/classes/task/BuildUpBuilding.usl
@@ -2,8 +2,9 @@ class CBuildUpBuilding inherit CTask
 
 	const real TESLA_LVL2_BONUS_RANGE		= 20.0;
 	const real TESLA_LVL2_BONUS_VALUE		= 0.5;
-	const real BABBAGE_LVL5_BONUS_VALUE	= 0.5;
-	const real SEAS_BETTER_TOOLS				= 0.75;
+	//const real BABBAGE_LVL5_BONUS_VALUE	= 0.5;
+	const real TESLA_LVL5_BONUS_VALUE		= 0.66; //Kr1s1m: 33% faster buildup
+	const real SEAS_BETTER_TOOLS			= 0.75; //Kr1s1m: 25% faster buildup
 
 	class CInvalid //obsolete, just for save loading
 		export var CFourCC	m_xLink;
@@ -453,21 +454,27 @@ class CBuildUpBuilding inherit CTask
 						xDiff/=TESLA_LVL2_BONUS_VALUE;
 						bTeslaBonus=true;
 					endif;
+					//Kr1s1m: If Tesla is tier 5 activate his cheif bonus globally, modifying xDiff.
+					if(pxTesla^.GetLevel()>=4)then
+						xDiff/=TESLA_LVL5_BONUS_VALUE;
+					endif;
 				endif;
 			endif;
 		end CheckTesla;
-		begin CheckBabbage;
-			var CObjHndl xBabbage=CNPCMgr.Get().GetPlayerNPC(pxBuilding^.GetOwner(), "babbage_s0");
-			if(!xBabbage.IsValid())then
-				xBabbage=CNPCMgr.Get().GetPlayerNPC(pxBuilding^.GetOwner(), "special_mobile_suit");
-			endif;
-			if(xBabbage.IsValid())then
-				var ^CFightingObj pxBabbage=cast<CFightingObj>(xBabbage.GetObj());
-				if(pxBabbage!=null && pxBabbage^.GetLevel()>=4)then
-					xDiff/=BABBAGE_LVL5_BONUS_VALUE;
-				endif;
-			endif;
-		end CheckBabbage;
+		//Kr1s1m: In Mirage Babbage chief bonus was changed to instead give 20 range and melee armor to all controlled infantry.
+		//Kr1s1m: The commented portion bellow gives global buildup speed, which is now Taslow chief bonus.
+		//begin CheckBabbage;
+			//var CObjHndl xBabbage=CNPCMgr.Get().GetPlayerNPC(pxBuilding^.GetOwner(), "babbage_s0");
+			//if(!xBabbage.IsValid())then
+				//xBabbage=CNPCMgr.Get().GetPlayerNPC(pxBuilding^.GetOwner(), "special_mobile_suit");
+			//endif;
+			//if(xBabbage.IsValid())then
+				//var ^CFightingObj pxBabbage=cast<CFightingObj>(xBabbage.GetObj());
+				//if(pxBabbage!=null && pxBabbage^.GetLevel()>=4)then
+					//xDiff/=BABBAGE_LVL5_BONUS_VALUE;
+				//endif;
+			//endif;
+		//end CheckBabbage;
 		begin CheckSEASBonus;
 			if(m_xBuilding.IsValid())then
 				var ^CGameObj pxBldg = m_xBuilding.GetObj();


### PR DESCRIPTION
- Taslow now properly grants 33% global build up speed
- Babbage no longer still gives 50% global build up speed, even though his chief bonus was changed to give global melee and ranged armor to all infantry long ago