### PR TITLE
added modifications state from MIRAGE repository

### DIFF
--- a/BetaTest267/Scripts/Game/Game.usl
+++ b/BetaTest267/Scripts/Game/Game.usl
@@ -1927,7 +1927,9 @@ class CGameInst inherit IEvtInterface
 			var ^CObj pxObj=xHovered[i].GetObj();
 			if(pxObj==null)then continue; endif;
 			//disable for AlienCommands
-			if(bHasOwnOwner && pxObj^.GetOwner()!=iOwnOwner && (CMirageClnMgr.Get().CheckAlienCommands() && (!pxObj^.IsEnemy() && pxObj^.GetOwner()==-1)))then continue; endif;
+			var int iOwner = pxObj^.GetOwner();
+			var int iDiploStatus = CGameWrap.GetDiplomacyMgr().GetTheirOpinion(iOwner);
+			if(bHasOwnOwner && iOwner!=iOwnOwner && (CMirageClnMgr.Get().CheckAlienCommands() && (iDiploStatus==2 && iOwner==-1)))then continue; endif;
 			if(bHasUnits)then
 				var CFourCC xType=pxObj^.GetType();
 				//Henry: added seas carrier

--- a/BetaTest267/Scripts/Game/UI/CommandBarEx/CommandBar.usl
+++ b/BetaTest267/Scripts/Game/UI/CommandBarEx/CommandBar.usl
@@ -749,7 +749,10 @@ class CActionMenu
 			for(i=0) cond(i<iC) iter(++i) do
 				if(!xSel[i].IsValid())then xSel.DeleteEntry(i--); --iC; continue; endif;
 				var ^CObj pxO=xSel[i].GetObj();
-				if(pxO^.GetOwner()!=iPlayerID)then xSel.DeleteEntry(i--); --iC; continue; endif;
+				var int iOwner = pxO^.GetOwner();
+				var int iDiploStatus = CGameWrap.GetDiplomacyMgr().GetTheirOpinion(iOwner);
+				var bool bAllyCommands = CMirageClnMgr.Get().CheckAlienCommands();
+				if((iOwner!=iPlayerID) && !(bAllyCommands==true && iDiploStatus==2))then xSel.DeleteEntry(i--); --iC; continue; endif;
 				var string sCN=pxO^.GetClassName();
 				if(sCN=="aje_torpedo_turtle"||sCN=="aje_gallimimus"||sCN=="aje_tracker_dino"||sCN=="hu_kennel_smilodon"||sCN=="ninigi_dilophosaurus"||sCN=="seas_stygimoloch")then continue; endif;
 				//RT#14694 deactivation of command buttons for ninigi water mines
@@ -3609,9 +3612,10 @@ class CCommandBar inherit CWindow
 					sClass += ":"+pxAttribs^.GetValue("ObjFlag");
 				endif;
 				var int iIdx=asClasses.FindEntry(sClass);
-				var bool bOwnUnit=pxO^.GetOwner()==iPlayerID;
 				var bool bIsBuilding=pxO^.GetType()=="BLDG";
-				if(bOwnUnit)then
+				var int iOwner = pxO^.GetOwner();
+				var int iDiploStatus = CGameWrap.GetDiplomacyMgr().GetTheirOpinion(iOwner);
+				if(iOwner==iPlayerID || (CMirageClnMgr.Get().CheckAlienCommands() && iDiploStatus==2))then
 					if(iIdx<0)then
 						if(bIsBuilding && !bAlreadyBuilding)then
 							asClasses.AddEntry(sClass);

--- a/BetaTest267/Scripts/Game/controller/GameInputController.usl
+++ b/BetaTest267/Scripts/Game/controller/GameInputController.usl
@@ -1117,7 +1117,8 @@ class CGameInputController inherit CInputController
 				if(pxSubject!=null)then
 					//disable for AlienCommands
 					var int iOwner = pxSubject^.GetOwner();
-					if(iOwner==CGameWrap.GetClient().GetPlayer().GetID() || (CMirageClnMgr.Get().CheckAlienCommands() && iOwner != -1 && !pxSubject^.IsEnemy()))then
+					var int iDiploStatus = CGameWrap.GetDiplomacyMgr().GetTheirOpinion(iOwner);
+					if(iOwner==CGameWrap.GetClient().GetPlayer().GetID() || (CMirageClnMgr.Get().CheckAlienCommands() && iOwner != -1 && iDiploStatus==2))then
 						xOwner.AddEntry(xSubject);
 						bOwn=true;
 					else
@@ -1972,7 +1973,9 @@ class CGameInputController inherit CInputController
 						var ^CObj pxObj=xTmpList[i].GetObj();
 						if(pxObj==null)then continue; endif;
 						//disable for AlienCommands
-						if(bHasOwnOwner && pxObj^.GetOwner()!=iOwnOwner || (CMirageClnMgr.Get().CheckAlienCommands() && (!pxObj^.IsEnemy() || pxObj^.GetOwner()==-1)))then continue; endif;
+						var int iOwner = pxObj^.GetOwner();
+						var int iDiploStatus = CGameWrap.GetDiplomacyMgr().GetTheirOpinion(iOwner);
+						if(bHasOwnOwner && iOwner!=iOwnOwner || (CMirageClnMgr.Get().CheckAlienCommands() && (iDiploStatus==2 || iOwner==-1)))then continue; endif;
 						
 						if(bHasUnits)then
 							//Henry: fix for seas carrier


### PR DESCRIPTION
- ability to command an ally during a match (alien commands) determined based on checking diplomacy status using GetTheirOpinion(iOwner);
- command bar is added to selection when alien commands and diplo status is correct but cooldowns and production queues do not work, buildings cannot be placed from the building menu with TT Stealing mirage server setting set to off, building can be placed with TT stealing on but their owner is not the controlled ally but the controlling player, Taslow uses controlling player build menu (instead of controlled player) but cannot place buildings, allied ship buildings cant be moved, upgrades applied to controlling player, resource costs taken from controlling player (since owner of building is the controlling player)