### PR TITLE
added main mirage custom map settings logic

### DIFF
--- a/BetaTest267/Scripts/Game/UI/LevelSettingsPage.usl
+++ b/BetaTest267/Scripts/Game/UI/LevelSettingsPage.usl
@@ -647,6 +647,44 @@ class CLevelSettingsPageHost inherit CLevelSettingsPage
 		CMultiPlayerClientMgr.Get().SetNumPlayers(iNumPlayers);
 	endconstructor;
 	
+	proc void UpdateCustomMapAttribs(string p_sLevelName)
+		KLog.LogSpam("Kr1s1m", "CMirageServer::UpdateCustomMapAttribs("+p_sLevelName+") begin");
+		var CPropDB xCustomMapMirageSettingsDB;
+		xCustomMapMirageSettingsDB.Load(CClientWrap.GetUrsRelPath()+"/data/base/scripts/game/misc/CustomMapMirageSettings.txt");
+		var ^CPropDB.CNode pxLevelsNode = xCustomMapMirageSettingsDB.GetRoot().Get("Levels");
+		if(pxLevelsNode!=null)then
+			var string sLevelName = p_sLevelName;
+			sLevelName.Replace(" ", "_");
+			var ^CPropDB.CNode pxLevelNameNode = pxLevelsNode^.Get(sLevelName);
+			if(pxLevelNameNode!=null)then
+				KLog.LogSpam("Kr1s1m", pxLevelNameNode^.Name()+" custom map level matched");
+				var bool bLock = true;
+				var int k, kC=pxLevelNameNode^.NumSubs();
+				for(k=0)cond(k<kC)iter(k++)do//Kr1s1m: Iterate the adjust categories inside the level name node
+					var ^CPropDB.CNode pxAdjustCategoryNode = ^(pxLevelNameNode^.Get(k));
+					KLog.LogSpam("Kr1s1m", "adjusting "+pxAdjustCategoryNode^.Name()+" mirage settings");
+					var int i, iC=pxAdjustCategoryNode^.NumSubs();
+					for(i=0)cond(i<iC)iter(i++)do//Kr1s1m: Iterate the setting types inside a given adjust category node
+						var ^CPropDB.CNode pxSettingTypeNode = ^(pxAdjustCategoryNode^.Get(i));
+						var string sSettingType = pxSettingTypeNode^.Name();
+						var int j, jC=pxSettingTypeNode^.NumSubs();
+						for(j=0)cond(j<jC)iter(j++)do//Kr1s1m: Iterate the setting nodes inside a given setting type node
+							var ^CPropDB.CNode pxSettingNode = ^(pxSettingTypeNode^.Get(j));
+							var string sSettingName = pxSettingNode^.Name();
+							var string sValue = pxSettingNode^.Value();
+							CGameWrap.GetGame().SetAttrib(sSettingName, sValue.ToInt());
+							KLog.LogSpam("Kr1s1m", "CGameWrap.GetGame().SetAttrib("+sSettingName+", "+sValue+")");
+						endfor;
+					endfor;
+				endfor;
+			else
+				KLog.LogSpam("Kr1s1m", p_sLevelName+" is not a custom map. Nothing has been updated.");
+			endif;
+		endif;
+		KLog.LogSpam("Kr1s1m", "CMirageServer::UpdateCustomMapAttribs("+p_sLevelName+") end");
+	endproc;
+	
+	
 	proc bool OnSelectMap()
 		super.OnSelectMap();
 		var int iIndex=m_pxHostMapList^.GetSelectedItem();
@@ -657,12 +695,14 @@ class CLevelSettingsPageHost inherit CLevelSettingsPage
 				var ^CMapInfoList.CMapInfo pxMapInfo=m_xMapInfoList.GetMapInfo_CheckSumme(sLevelCheckSumme);
 				if(pxMapInfo!=null)then
 					//var string sPath=CClientWrap.GetUrsRelPath()+"/Data/Base/Maps/Multiplayer/"+pxMapInfo^.GetFile();
-					CUIStateMgr.Get().SetLoadScreenInfo(CUIStateMgr.CLoadScreenInfo.LOADSCR_MULTIPLAYER,pxMapInfo^.GetMapName(),pxMapInfo^.GetLevelInfo().GetLevelCheckSumme());
+					var string sLevelName=pxMapInfo^.GetMapName();
+					CUIStateMgr.Get().SetLoadScreenInfo(CUIStateMgr.CLoadScreenInfo.LOADSCR_MULTIPLAYER,sLevelName,pxMapInfo^.GetLevelInfo().GetLevelCheckSumme());
 					var string sPath=pxMapInfo^.GetFile();
 					sPath.Replace("/BoosterPack1/","/Base/"); // Henry: on dedicated server the maps from Boosterpack and Mirage were unusable without this
 					sPath.Replace("/MIRAGE/","/Base/");
 					CEvt_LoadLevelPreview.Send(sPath);
 					CUIStateMgr.Get().SetSelectedMapFile(sPath);
+					UpdateCustomMapAttribs(sLevelName);
 				endif;
 			endif;
 		else

--- a/BetaTest267/Scripts/Game/UI/Mirage_UI_scripts.usl
+++ b/BetaTest267/Scripts/Game/UI/Mirage_UI_scripts.usl
@@ -486,7 +486,106 @@ class CMirageServer inherit CWindow
 		return(true);
 	endproc;
 	
-	class CAdjustWorld inherit CStateUIWnd;
+	class CAdjustMirage inherit CStateUIWnd
+		
+		var string m_sAdjustCategory;
+		var string m_sLevelName;
+		
+		var bool m_bInit;
+		
+		export constructor()
+			m_sAdjustCategory = "?";
+			m_sLevelName = "?";
+			m_bInit = false;
+		endconstructor;
+		
+		export constructor(string p_sAdjustCategory)
+			Init(p_sAdjustCategory);
+		endconstructor;
+		
+		export proc bool Init(string p_sAdjustCategory)
+			m_sAdjustCategory = p_sAdjustCategory;
+			var ^CPropDB pxGenericData=^(CGameWrap.GetClient().GetLevelInfo().GetGenericData());
+			m_sLevelName=(pxGenericData^)["Base/LevelName"].Value();
+			KLog.LogSpam("Kr1s1m","Mirage_UI_scripts::CAdjust"+m_sAdjustCategory+" m_sLevelName="+m_sLevelName);
+			m_bInit = m_sAdjustCategory!="" && m_sAdjustCategory!="?" && m_sLevelName!="" && m_sLevelName!="?";
+			return m_bInit;
+		endproc;
+		
+		export proc void UpdateCustomMapMirageSettings()
+			KLog.LogSpam("Kr1s1m", "CMirageServer::UpdateCustomMapMirageSettings begin");
+			var CPropDB xCustomMapMirageSettingsDB;
+			xCustomMapMirageSettingsDB.Load(CClientWrap.GetUrsRelPath()+"/data/base/scripts/game/misc/CustomMapMirageSettings.txt");
+			var ^CPropDB.CNode pxLevelsNode = xCustomMapMirageSettingsDB.GetRoot().Get("Levels");
+			if(pxLevelsNode!=null)then
+				var string sLevelName = m_sLevelName;
+				sLevelName.Replace(" ", "_");
+				var ^CPropDB.CNode pxLevelNameNode = pxLevelsNode^.Get(sLevelName);
+				if(pxLevelNameNode!=null)then
+					KLog.LogSpam("Kr1s1m", pxLevelNameNode^.Name()+" custom map level matched");
+					var int k, kC=pxLevelNameNode^.NumSubs();
+					//Kr1s1m: TODO: replace for loop with .Get(m_sAdjustCategory)
+					for(k=0)cond(k<kC)iter(k++)do//Kr1s1m: Iterate the adjust categories inside the level name node
+						var ^CPropDB.CNode pxAdjustCategoryNode = ^(pxLevelNameNode^.Get(k));
+						if(pxAdjustCategoryNode^.Name()!=m_sAdjustCategory)then
+							continue; //Kr1s1m: skip the categories which don't match the adjust category field
+						else
+							KLog.LogSpam("Kr1s1m", "adjusting mirage "+pxAdjustCategoryNode^.Name()+" settings");
+						endif;
+						var int i, iC=pxAdjustCategoryNode^.NumSubs();
+						for(i=0)cond(i<iC)iter(i++)do//Kr1s1m: Iterate the setting types inside a given adjust category node
+							var ^CPropDB.CNode pxSettingTypeNode = ^(pxAdjustCategoryNode^.Get(i));
+							var string sSettingType = pxSettingTypeNode^.Name();
+							var int j, jC=pxSettingTypeNode^.NumSubs();
+							for(j=0)cond(j<jC)iter(j++)do//Kr1s1m: Iterate the setting nodes inside a given setting type node
+								var ^CPropDB.CNode pxSettingNode = ^(pxSettingTypeNode^.Get(j));
+								var string sSettingName = pxSettingNode^.Name();
+								var string sValue = pxSettingNode^.Value();
+								SetAndLockMirageSetting(sSettingType, sSettingName, sValue, true);
+							endfor;
+						endfor;
+					endfor;
+				else
+					KLog.LogSpam("Kr1s1m", m_sLevelName+" is not a custom map. Nothing has been updated.");
+				endif;
+			endif;
+			KLog.LogSpam("Kr1s1m", "CMirageServer::UpdateCustomMapMirageSettings end");
+		endproc;
+	
+		export proc void SetAndLockMirageSetting(string p_sSettingType, string p_sSettingName, string p_sValue, bool p_bLock);
+			KLog.LogSpam("Kr1s1m", "CMirageServer::SetAndLockMirageSetting begin");
+			if(p_sValue=="")then return; endif;
+			var CConfig xConf;
+			var int iOldValue = xConf.GetSetI("Server/GameplayOptions/"+p_sSettingName, 0);
+			var int iValue = p_sValue.ToInt();
+			if(p_sSettingType=="CheckBox")then
+				var ^CCheckBox pxCheckBox = cast<CCheckBox>(GetControl(p_sSettingName));
+				pxCheckBox^.SetChecked(iValue);
+				pxCheckBox^.SetDisabled(p_bLock);
+			elseif(p_sSettingType=="DropList")then
+				var ^CDropList pxDrop = cast<CDropList>(GetControl(p_sSettingName+"Droplist"));
+				if(pxDrop^.NumItems()>iValue && pxDrop^.NumItems()>0)then
+					pxDrop^.Select(iValue);
+				endif;
+				pxDrop^.SetDisabled(p_bLock);
+			elseif(p_sSettingType=="SpinCtrlNumber")then
+				var ^CSpinCtrlNumber pxSpinCtrl = cast<CSpinCtrlNumber>(GetControl(p_sSettingName+"SpinCtrl"));
+				pxSpinCtrl^.SetValue(iValue);
+				pxSpinCtrl^.SetEditable(false);
+				pxSpinCtrl^.SetDisabled(p_bLock);
+			endif;
+			xConf.SetI("Server/GameplayOptions/"+p_sSettingName, iOldValue);//Kr1s1m: Keep the user config intact.
+			//CGameWrap.GetGame().SetAttrib(p_sSettingName,iValue);
+			//KLog.LogSpam("Kr1s1m", "CGameWrap.GetGame().SetAttrib("+p_sSettingName+", "+p_sValue+")");
+			var string sLocked = "";
+			if(p_bLock)then sLocked = "(locked)"; endif;
+			KLog.LogSpam("Kr1s1m", "p_sSettingType: "+p_sSettingType+" p_sSettingName: "+p_sSettingName+" ====> "+p_sValue+sLocked);
+			KLog.LogSpam("Kr1s1m", "CMirageServer::SetAndLockMirageSetting end");
+		endproc;
+	
+	endclass;
+	
+	class CAdjustWorld inherit CAdjustMirage;
 		
 		export constructor()
 			if(!InitFromResource("UI/MirageSettings","AdjustWorld"))then
@@ -569,6 +668,10 @@ class CMirageServer inherit CWindow
 			pxCheckBox^.m_xOnStateChange=OnEnableCorpseDamage;
 			pxGame^.SetAttrib(sName,bEnabled);
 			
+			if(super.Init("World"))then
+				super.UpdateCustomMapMirageSettings();
+			endif;
+			
 			pxButton = cast<CButton>(GetControl("OkButton"));
 			pxButton^.m_xOnClick=OnOk;
 			
@@ -635,7 +738,7 @@ class CMirageServer inherit CWindow
 		
 	endclass;
 	
-	class CAdjustBuilding inherit CStateUIWnd;
+	class CAdjustBuilding inherit CAdjustMirage;
 		
 		export constructor()
 			if(!InitFromResource("UI/MirageSettings","AdjustBuilding"))then
@@ -725,6 +828,10 @@ class CMirageServer inherit CWindow
 			pxCheckBox^.m_xOnStateChange=OnEnableAllyBuildup;
 			pxGame^.SetAttrib(sName,bEnabled);
 			
+			if(super.Init("Building"))then
+				super.UpdateCustomMapMirageSettings();
+			endif;
+			
 			pxButton = cast<CButton>(GetControl("OkButton"));
 			pxButton^.m_xOnClick=OnOk;
 			
@@ -799,7 +906,7 @@ class CMirageServer inherit CWindow
 		
 	endclass;
 	
-	class CAdjustUnit inherit CStateUIWnd;
+	class CAdjustUnit inherit CAdjustMirage;
 		
 		export constructor()
 			if(!InitFromResource("UI/MirageSettings","AdjustUnit"))then
@@ -995,6 +1102,10 @@ class CMirageServer inherit CWindow
 			pxSpinCtrl^.m_xOnChange=OnChangeTransportHealing;
 			pxGame^.SetAttrib(sName,iSetting);
 			
+			if(super.Init("Unit"))then
+				super.UpdateCustomMapMirageSettings();
+			endif;
+			
 			pxButton = cast<CButton>(GetControl("OkButton"));
 			pxButton^.m_xOnClick=OnOk;
 			
@@ -1182,7 +1293,7 @@ class CMirageServer inherit CWindow
 		
 	endclass;
 	
-	class CAdjustGameMechanic inherit CStateUIWnd;
+	class CAdjustGameMechanic inherit CAdjustMirage;
 		
 		export constructor()
 			if(!InitFromResource("UI/MirageSettings","AdjustGameMechanic"))then
@@ -1407,6 +1518,11 @@ class CMirageServer inherit CWindow
 			pxCheckBox^.m_xOnStateChange=OnEnableAlienCommands;
 			pxGame^.SetAttrib(sName,bEnabled);
 			
+			
+			if(super.Init("GameMechanic"))then
+				super.UpdateCustomMapMirageSettings();
+			endif;
+			
 			pxButton = cast<CButton>(GetControl("OkButton"));
 			pxButton^.m_xOnClick=OnOk;
 			
@@ -1591,7 +1707,7 @@ class CMirageServer inherit CWindow
 		
 	endclass;
 	
-	class CAdjustTimer inherit CStateUIWnd;
+	class CAdjustTimer inherit CAdjustMirage;
 		
 		export constructor()
 			if(!InitFromResource("UI/MirageSettings","AdjustTimer"))then
@@ -1752,6 +1868,10 @@ class CMirageServer inherit CWindow
 			pxSpinCtrl^.m_xOnChange=OnChangeSandGlass;
 			pxGame^.SetAttrib(sName,iSetting);
 			
+			if(super.Init("Timer"))then
+				super.UpdateCustomMapMirageSettings();
+			endif;
+			
 			pxButton = cast<CButton>(GetControl("OkButton"));
 			pxButton^.m_xOnClick=OnOk;
 			
@@ -1899,7 +2019,7 @@ class CMirageServer inherit CWindow
 		
 	endclass;
 	
-	class CAdjustPhantomMode inherit CStateUIWnd;
+	class CAdjustPhantomMode inherit CAdjustMirage;
 		
 		var bool m_bOff, m_bRandom;
 		var int m_iAvailable, m_iPlayers, m_iMid;
@@ -2072,6 +2192,10 @@ class CMirageServer inherit CWindow
 			pxCheckBox^.SetDisabled(m_bOff);
 			pxGame^.SetAttrib(sName,pxCheckBox^.GetChecked());
 			m_apxBoxes.AddEntry(pxCheckBox);
+			
+			if(super.Init("PhantomMode"))then
+				super.UpdateCustomMapMirageSettings();
+			endif;
 			
 			pxButton = cast<CButton>(GetControl("OkButton"));
 			pxButton^.m_xOnClick=OnOk;

--- a/BetaTest267/Scripts/Game/misc/CustomMapMirageSettings.txt
+++ b/BetaTest267/Scripts/Game/misc/CustomMapMirageSettings.txt
@@ -1,0 +1,40 @@
+Root {
+	Levels {
+		Single_01 {
+			World {
+				CheckBox {
+					FruitsRemovement = '1'
+					NestRespawn = '1'
+				}
+			}
+			Unit {
+				SpinCtrlNumber {
+					TransportHealing = '10'
+				}
+			}
+			GameMechanic {
+				DropList {
+					DwnLvlSwitch = '2'
+				}
+			}
+		}
+		Single_02 {
+			World {
+				CheckBox {
+					FruitsRemovement = '0'
+					NestRespawn = '0'
+				}
+			}
+			Unit {
+				SpinCtrlNumber {
+					TransportHealing = '50'
+				}
+			}
+			GameMechanic {
+				DropList {
+					DwnLvlSwitch = '1'
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- settings are read, set and locked correctly, depending on map
- old non-custom map mirage settings are preserved in user config and thus loaded back when needed
- TODO: game attribs need testing inside game
- TODO: overview 1 and 2 pages not updating on their own like they should (they are based on attribs)